### PR TITLE
Fix for no auto update

### DIFF
--- a/src/Privatezilla/Settings/Updates/DisableUpdates.cs
+++ b/src/Privatezilla/Settings/Updates/DisableUpdates.cs
@@ -23,7 +23,7 @@ namespace Privatezilla.Setting.Updates
         public override bool CheckSetting()
         {
             return !(
-                    RegistryHelper.IntEquals(NoAutoUpdate, "NoAutoUpdate",0) &&
+                    RegistryHelper.IntEquals(NoAutoUpdate, "NoAutoUpdate", 1) &&
                     RegistryHelper.IntEquals(AUOptions, "AUOptions", 2) &&
                     RegistryHelper.IntEquals(ScheduledInstallDay, "ScheduledInstallDay", 0) &&
                     RegistryHelper.IntEquals(ScheduledInstallTime, "ScheduledInstallTime", 3)
@@ -34,7 +34,7 @@ namespace Privatezilla.Setting.Updates
         {
             try
             {
-                Registry.SetValue(NoAutoUpdate, "NoAutoUpdate", 0, RegistryValueKind.DWord);
+                Registry.SetValue(NoAutoUpdate, "NoAutoUpdate", 1, RegistryValueKind.DWord);
                 Registry.SetValue(AUOptions, "AUOptions", 2, RegistryValueKind.DWord);
                 Registry.SetValue(ScheduledInstallDay, "ScheduledInstallDay", 0, RegistryValueKind.DWord);
                 Registry.SetValue(ScheduledInstallTime, "ScheduledInstallTime", 3, RegistryValueKind.DWord);
@@ -50,7 +50,7 @@ namespace Privatezilla.Setting.Updates
         {
             try
             {
-                Registry.SetValue(NoAutoUpdate, "NoAutoUpdate", 1, RegistryValueKind.DWord);
+                Registry.SetValue(NoAutoUpdate, "NoAutoUpdate", 0, RegistryValueKind.DWord);
 
                 var RegKey = Registry.LocalMachine.OpenSubKey(@"Software\Policies\Microsoft\Windows\WindowsUpdate\AU", true);
                 RegKey.DeleteValue("AUOptions");


### PR DESCRIPTION
According to https://docs.microsoft.com/de-de/security-updates/windowsupdateservices/18127499:

0 = Enable Automatic Updates.
1 = Disable Automatic Updates.

Current code sets it to 0, which is the opposite effect as it enables the auto update instead of disabling it.